### PR TITLE
Added option to prevent mid range pull up bar

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ionic-pullup",
   "description": "Ionic pull up footer",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "homepage": "https://github.com/arielfaur",
   "license": "MIT",
   "private": false,

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-  "name": "ionic-pullup-auxo",
+  "name": "ionic-pullup",
   "description": "Ionic pull up footer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/arielfaur",
   "license": "MIT",
   "private": false,

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ionic-pullup",
+  "name": "ionic-pullup-auxo",
   "description": "Ionic pull up footer",
   "version": "1.1.0",
   "homepage": "https://github.com/arielfaur",

--- a/dist/ion-pullup.js
+++ b/dist/ion-pullup.js
@@ -147,15 +147,22 @@ angular.module('ionic-pullup', [])
                           $element.css({'-webkit-transform': 'translate3d(0, ' + footer.posY + 'px, 0)', 'transform': 'translate3d(0, ' + footer.posY + 'px, 0)'});
                           break;
                       case 'dragend':
-                          $element.css({'transition': '300ms ease-in-out'});
-                          footer.lastPosY = footer.posY;
-                          if(!$scope.allowMidRange){
-                            if(footer.lastPosY > footer.posY;){
-                              collapse();
-                            }
-                            else if(footer.lastPosY < footer.posY;){
-                              expand();
-                            }
+                          console.log('$scope.allowMidRange',$scope.allowMidRange);
+                          if (!$scope.allowMidRange) {
+                              if (footer.lastPosY > footer.posY) {
+                                  expand();
+                                  $element.css({'transition': '300ms ease-in-out'});
+                                  $rootScope.$broadcast('ionPullUp:tap', footer.state);
+                              }
+                              else if (footer.lastPosY < footer.posY) {
+                                  collapse();
+                                  $element.css({'transition': '300ms ease-in-out'});
+                                  $rootScope.$broadcast('ionPullUp:tap', footer.state);
+                              }
+                          }
+                          else{
+                              $element.css({'transition': '300ms ease-in-out'});
+                              footer.lastPosY = footer.posY;
                           }
                           break;
                   }

--- a/dist/ion-pullup.js
+++ b/dist/ion-pullup.js
@@ -14,7 +14,8 @@ angular.module('ionic-pullup', [])
           scope: {
               onExpand: '&',
               onCollapse: '&',
-              onMinimize: '&'
+              onMinimize: '&',
+              allowMidRange: '='
           },
           controller: ['$scope', '$element', '$attrs', 'ionPullUpFooterState', 'ionPullUpFooterBehavior', function($scope, $element, $attrs, FooterState, FooterBehavior) {
               var
@@ -148,6 +149,14 @@ angular.module('ionic-pullup', [])
                       case 'dragend':
                           $element.css({'transition': '300ms ease-in-out'});
                           footer.lastPosY = footer.posY;
+                          if(!$scope.allowMidRange){
+                            if(footer.lastPosY > footer.posY;){
+                              collapse();
+                            }
+                            else if(footer.lastPosY < footer.posY;){
+                              expand();
+                            }
+                          }
                           break;
                   }
               };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ionic-pullup",
+  "name": "ionic-pullup-auxo",
   "private": false,
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Ionic pull up footer",
   "repository": "https://github.com/arielfaur",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ionic-pullup-auxo",
+  "name": "ionic-pullup",
   "private": false,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Ionic pull up footer",
   "repository": "https://github.com/arielfaur",
   "license": "MIT",


### PR DESCRIPTION
When the user is dragging the bar, if `allow-mid-range="false"` is set in the `ion-pull-up-footer` directive, then the bar will automatically follow it's path, collapsing or expanding.