### PR TITLE
Checking if childFooter is set before trying to expand

### DIFF
--- a/projects/ionic-pullup/src/lib/ionic-pullup.component.ts
+++ b/projects/ionic-pullup/src/lib/ionic-pullup.component.ts
@@ -198,6 +198,7 @@ export class IonicPullupComponent implements OnInit, AfterContentInit, OnChanges
   }
 
   expand() {
+    if (!this.childFooter) { return; }  
     this.footerMeta.lastPosY = this.footerMeta.toolbarDefaultExpandedPosition;
 
     // reset ionContent scaling


### PR DESCRIPTION
There are cases where the childFooter is null and we're getting this error. So similar to what you have on collapse we should validate first.

ERROR Error: Uncaught (in promise): TypeError: Cannot read property 'nativeElement' of null
TypeError: Cannot read property 'nativeElement' of null
    at IonicPullupComponent.expand (http://localhost/module-es2015.js:4817:49)